### PR TITLE
test.fileTests: fix caseExpr for empty name

### DIFF
--- a/src/test.ts
+++ b/src/test.ts
@@ -145,7 +145,7 @@ function toLineContext(file: string, index: number) {
 }
 
 export function fileTests(file: string, fileName: string, mayIgnore = defaultIgnore) {
-  let caseExpr = /\s*#\s*(.*)(?:\r\n|\r|\n)([^]*?)==+>([^]*?)(?:$|(?:\r\n|\r|\n)+(?=#))/gy
+  let caseExpr = /\s*#[ \t]*(.*)(?:\r\n|\r|\n)([^]*?)==+>([^]*?)(?:$|(?:\r\n|\r|\n)+(?=#))/gy
   let tests: {
     name: string,
     text: string,


### PR DESCRIPTION
problem was, `\s` matches newline

bad: text is parsed as name

```
> var e = /\s*#\s*(.*)(?:\r\n|\r|\n)([^]*?)==+>([^]*?)(?:$|(?:\r\n|\r|\n)+(?=#))/gy
undefined
> e.exec("#\na\n==>\nb").slice(1,3)
[ 'a', '' ]
```

good: name is empty

```
> var e = /\s*#[ \t]*(.*)(?:\r\n|\r|\n)([^]*?)==+>([^]*?)(?:$|(?:\r\n|\r|\n)+(?=#))/gy
undefined
> e.exec("#\na\n==>\nb").slice(1,3)
[ '', 'a\n' ]
```
