### PR TITLE
change import to refer to a specific file

### DIFF
--- a/src/rollup-plugin-lezer.js
+++ b/src/rollup-plugin-lezer.js
@@ -1,6 +1,6 @@
 import {resolve, dirname} from "path"
 import {promises as fs} from "fs"
-import {buildParserFile} from ".."
+import {buildParserFile} from "./index.ts"
 
 export function lezer() {
   let built = Object.create(null)


### PR DESCRIPTION
importing from a directory is not supported in esm, making things break when used in a package that has `type: 'module'` in its `package.json`

Tests still pass after the change.