### PR TITLE
[lezer-parser/lezer#32] Add "require" to keywords to avoid conflicts with environments that pre-define `require`

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1989,7 +1989,7 @@ const KEYWORDS = ["break", "case", "catch", "continue", "debugger", "default", "
                   "for", "function", "if", "return", "switch", "throw", "try", "var", "while", "with",
                   "null", "true", "false", "instanceof", "typeof", "void", "delete", "new", "in", "this",
                   "const", "class", "extends", "export", "import", "super", "enum", "implements", "interface",
-                  "let", "package", "private", "protected", "public", "static", "yield"]
+                  "let", "package", "private", "protected", "public", "static", "yield", "require"]
 
 /// Build the code that represents the parser tables for a given
 /// grammar description. The `parser` property in the return value


### PR DESCRIPTION
Fix for lezer-parser/lezer#32. All test pass.
Note that full fix for lezer-parser/lezer#32 will probably include a version bump/re-release of `@lezer/php` as well, once this is released.