### PR TITLE
Fix ES module build of rollup plugin

### DIFF
--- a/src/rollup-plugin-lezer.js
+++ b/src/rollup-plugin-lezer.js
@@ -1,6 +1,6 @@
 import {resolve, dirname} from "path"
 import {promises as fs} from "fs"
-import {buildParserFile} from ".."
+import {buildParserFile} from "@lezer/generator"
 
 export function lezer() {
   let built = Object.create(null)


### PR DESCRIPTION
This commit fixes issue [lezer-parser/lezer#30](https://github.com/lezer-parser/lezer/issues/30).

The problem is that the generated rollup plugin imported `buildParserFile` from the parent directory index. This is [not allowed in ES modules](https://nodejs.org/api/esm.html#mandatory-file-extensions) as file extensions are mandatory. A solution was to use the `--experimental-specifier-resolution=node` flag with node, for which support was dropped in Node v19. This issue resurfaced for me while trying to use the plugin with the most recent version of `vite`.

#9 tried fixing the issue, by simply importing the `index.ts` file. Problem there was that all dependencies were marked external in the rollup config, resulting in the import being copied verbatim and a broken rollup plugin.

Here we change the relative import to an import of the `@lezer/generator` package.
(I considered using `./index.js` since that is the ES module output file, but that I presume would break when using the cjs artifacts, since the import is not touched by rollup and not rewritten to the, then correct `index.cjs`.)