### PR TITLE
Make error message for conflict contain suggestions of a couple resolution paths

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1634,8 +1634,12 @@ class MainTokenSet extends TokenSet {
             let example = conflict.exampleA ? ` (example: ${JSON.stringify(conflict.exampleA)}${
               conflict.exampleB ? ` vs ${JSON.stringify(conflict.exampleB)}` : ""})` : ""
             errors.push({
-              error: `Overlapping tokens ${term.name} and ${conflicting.name} used in same context${example}\n` +
-                `After: ${state.set[0].trail()}`,
+              error: 
+                `Overlapping tokens ${term.name} and ${conflicting.name} used in same context${example}\n` +
+                `After: ${state.set[0].trail()}\n` + 
+                `You may resolve this conflict by declaring a \`@precedence rule\`, `+
+                `(example: \`@precedence { ${term.name}, ${conflicting.name} }\`) ` + 
+                `or adjusting the character sets that ${term.name} and ${conflicting.name} consist of.`,
               conflict
             })
           }


### PR DESCRIPTION
I started here: https://discuss.codemirror.net/t/how-can-i-help-make-grammar-authoring-less-terse-unhelpful/6286/1

My hope is to learn Lezer by helping the errors reported be less terse, and provide a little more guidance.

What has been done in this PR is focused around the overlapping tokens message, and the suggestions added may not be complete, but it's a start! We can iterate and improve the messaging together. 

---------------------------

As an aside, I noticed there was no CONTRIBUTING.md, dev section of the README, or .github/ci.yml, so I'm not sure how to run the tests, I kept getting errors locally.

--------------------

Update!

`npm run build main && npm run test` passes!

_so_, that means there is no test testing for an exact error message