### PR TITLE
Performance improvement: Lookup table for State.actions

### DIFF
--- a/src/automaton.ts
+++ b/src/automaton.ts
@@ -502,15 +502,13 @@ function canMerge(a: State, b: State, mapping: readonly number[]) {
     if (goto.term == other.term && mapping[goto.target.id] != mapping[other.target.id]) return false
   }
   actions: for (let action of a.actions) {
-    let conflict = false
     const matchingActions = b.filterByTermHash(action.term.hash);
     for (let other of matchingActions) if (other.term == action.term) {
       if (action instanceof Shift
           ? other instanceof Shift && mapping[action.target.id] == mapping[other.target.id]
           : other.eq(action)) continue actions
-      conflict = true
+      return false
     }
-    if (conflict) return false
   }
   return true
 }

--- a/src/automaton.ts
+++ b/src/automaton.ts
@@ -392,6 +392,7 @@ function findConflictOrigin(a: Pos, b: Pos) {
 // Builds a full LR(1) automaton
 export function buildFullAutomaton(terms: TermSet, startTerms: Term[], first: {[name: string]: Term[]}) {
   let states: State[] = []
+  let statesBySetHash: {[hash: number]: State[]} = {}
   let cores: {[hash: number]: Core[]} = {}
   let t0 = Date.now()
   function getState(core: readonly Pos[], top?: Term) {
@@ -409,9 +410,13 @@ export function buildFullAutomaton(terms: TermSet, startTerms: Term[], first: {[
 
     let set = closure(core, first)
     let hash = hashPositions(set), found
-    if (!top) for (let state of states) if (state.hash == hash && state.hasSet(set)) found = state
+    if (!top) for (let state of statesBySetHash[hash] ?? []) if (state.hash == hash && state.hasSet(set)) found = state
     if (!found) {
       found = new State(states.length, set, 0, skip!, hash, top)
+      if(statesBySetHash[hash] == null) {
+        statesBySetHash[hash] = []
+      }
+      statesBySetHash[hash].push(found)
       states.push(found)
       if (timing && states.length % 500 == 0)
         console.log(`${states.length} states after ${((Date.now() - t0) / 1000).toFixed(2)}s`)

--- a/src/automaton.ts
+++ b/src/automaton.ts
@@ -392,8 +392,7 @@ function findConflictOrigin(a: Pos, b: Pos) {
 // Builds a full LR(1) automaton
 export function buildFullAutomaton(terms: TermSet, startTerms: Term[], first: {[name: string]: Term[]}) {
   let states: State[] = []
-  let statesBySetHash: {[hash: number]: State[]} = {}
-  let cores: {[hash: number]: Core[]} = {}
+    let cores: {[hash: number]: Core[]} = {}
   let t0 = Date.now()
   function getState(core: readonly Pos[], top?: Term) {
     if (core.length == 0) return null
@@ -410,14 +409,10 @@ export function buildFullAutomaton(terms: TermSet, startTerms: Term[], first: {[
 
     let set = closure(core, first)
     let hash = hashPositions(set), found
-    if (!top) for (let state of statesBySetHash[hash] ?? []) if (state.hash == hash && state.hasSet(set)) found = state
+    if (!top) for (let state of states) if (state.hash == hash && state.hasSet(set)) found = state
     if (!found) {
       found = new State(states.length, set, 0, skip!, hash, top)
-      if(statesBySetHash[hash] == null) {
-        statesBySetHash[hash] = []
-      }
-      statesBySetHash[hash].push(found)
-      states.push(found)
+            states.push(found)
       if (timing && states.length % 500 == 0)
         console.log(`${states.length} states after ${((Date.now() - t0) / 1000).toFixed(2)}s`)
     }

--- a/src/automaton.ts
+++ b/src/automaton.ts
@@ -392,7 +392,7 @@ function findConflictOrigin(a: Pos, b: Pos) {
 // Builds a full LR(1) automaton
 export function buildFullAutomaton(terms: TermSet, startTerms: Term[], first: {[name: string]: Term[]}) {
   let states: State[] = []
-    let cores: {[hash: number]: Core[]} = {}
+  let cores: {[hash: number]: Core[]} = {}
   let t0 = Date.now()
   function getState(core: readonly Pos[], top?: Term) {
     if (core.length == 0) return null
@@ -412,7 +412,7 @@ export function buildFullAutomaton(terms: TermSet, startTerms: Term[], first: {[
     if (!top) for (let state of states) if (state.hash == hash && state.hasSet(set)) found = state
     if (!found) {
       found = new State(states.length, set, 0, skip!, hash, top)
-            states.push(found)
+      states.push(found)
       if (timing && states.length % 500 == 0)
         console.log(`${states.length} states after ${((Date.now() - t0) / 1000).toFixed(2)}s`)
     }

--- a/src/automaton.ts
+++ b/src/automaton.ts
@@ -497,7 +497,7 @@ function applyCut(set: readonly Pos[]): readonly Pos[] {
   return found || set
 }
 
-function canMergeInner(a: State, b: State, mapping: readonly number[]) {
+function canMerge(a: State, b: State, mapping: readonly number[]) {
   for (let goto of a.goto) for (let other of b.goto) {
     if (goto.term == other.term && mapping[goto.target.id] != mapping[other.target.id]) return false
   }
@@ -513,10 +513,6 @@ function canMergeInner(a: State, b: State, mapping: readonly number[]) {
     if (conflict) return false
   }
   return true
-}
-
-function canMerge(a: State, b: State, mapping: readonly number[]) {
-  return canMergeInner(a, b, mapping) && canMergeInner(b, a, mapping)
 }
 
 function mergeStates(states: readonly State[], mapping: readonly number[]) {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -26,7 +26,7 @@ export function hasProps(props: Props) {
 let termHash = 0
 
 export class Term {
-  hash = ++termHash // Used for sorting and hashing during parser generation
+  readonly hash = ++termHash // Used for sorting and hashing during parser generation
   id = -1 // Assigned in a later stage, used in actual output
   // Filled in only after the rules are simplified, used in automaton.ts
   rules: Rule[] = []


### PR DESCRIPTION
- Caches State.actions in a lookup table, keyed by the task hash
  - Improves performance from 145s to 57s in my grammar with the performance gain in optimizing the "collapse pass"


Fixes https://github.com/lezer-parser/lezer/issues/42