### PR TITLE
fix: stringify numeric separated literals with a leading zero

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -475,7 +475,7 @@ class Builder {
     })
 
     function specializationTableString(table: {[name: string]: number}) {
-      return "{__proto__:null," + Object.keys(table).map(key => `${/\W/.test(key) ? JSON.stringify(key) : key}:${table[key]}`)
+      return "{__proto__:null," + Object.keys(table).map(key => `${/\W/.test(key) || /^0_\d.*/.test(key) ? JSON.stringify(key) : key}:${table[key]}`)
         .join(", ") + "}"
     }
 


### PR DESCRIPTION
More examples of invalid numbers:
https://github.com/microsoft/TypeScript/issues/39563

For this grammar

```grammar
@top Program {
    repro
}

repro { var | tok }

@tokens {
    var { ![\n] }
}

tok { @specialize<var, "0_2"> }
```

I now get 

```console
// This file was generated by lezer-generator. You probably shouldn't edit it.
import {LRParser} from "@lezer/lr"
const spec_var = {__proto__:null,"0_2":10}
export const parser = LRParser.deserialize({
  version: 14,
  states: "bOQOPOOOOOO'#C_'#C_QOOOOO",
  stateData: "Y~OSPOTPO~O",
  goto: "WSPPPTRQO",
  nodeNames: "⚠ Program",
  maxTerm: 5,
  skippedNodes: [0],
  repeatNodeCount: 0,
  tokenData: "j~RSOY_Z;'S_;'S;=`d<%lO_~dOS~~gP;=`<%l_",
  tokenizers: [0],
  topRules: {"Program":[0,1]},
  specialized: [{term: 4, get: (value) => spec_var[value] || -1}],
  tokenPrec: 0
})
```

notice `"0_2"`

Before, `0_2:10` produced a syntax error.