### PR TITLE
Migrate to unplugin

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,7 +2,7 @@ import {build, watch} from "@marijn/buildtool"
 import {fileURLToPath} from "url"
 import {dirname, join} from "path"
 import {mkdirSync} from "fs"
-import * as esbuild from "esbuild"
+import * as tsup from "tsup"
 
 let tsOptions = {
   lib: ["dom", "es2016"],
@@ -14,20 +14,16 @@ let base = dirname(fileURLToPath(import.meta.url)), src = join(base, "src"), dis
 let main = join(src, "index.ts"), mainConf = {tsOptions}
 let test = join(src, "test.ts"), testConf = {tsOptions, bundleName: "test"}
 
-let unpluginFile = join(src, "unplugin-lezer.js")
+let unpluginFile = join(src, "unplugin-lezer.ts")
 try { mkdirSync(dist) } catch {}
 
-["cjs", "esm"].map(format =>
-  esbuild.buildSync({
-    entryPoints: [unpluginFile],
-    write: true,
-    bundle: true,
-    platform: "node",
-    format,
-    outExtension: { '.js': format === "esm" ? ".js" : ".cjs" },
-    outdir: dist,
-  })
-)
+tsup.build({
+  entry: { unplugin: unpluginFile },
+  dts: true,
+  format: ["cjs", "esm"],
+  outdir: dist,
+  skipNodeModulesBundle: true,
+})
 
 if (process.argv.includes("--watch")) {
   watch([main], [], mainConf)

--- a/build.js
+++ b/build.js
@@ -1,8 +1,8 @@
 import {build, watch} from "@marijn/buildtool"
 import {fileURLToPath} from "url"
 import {dirname, join} from "path"
-import {readFileSync, writeFileSync, mkdirSync} from "fs"
-import {rollup} from "rollup"
+import {mkdirSync} from "fs"
+import * as esbuild from "esbuild"
 
 let tsOptions = {
   lib: ["dom", "es2016"],
@@ -14,20 +14,20 @@ let base = dirname(fileURLToPath(import.meta.url)), src = join(base, "src"), dis
 let main = join(src, "index.ts"), mainConf = {tsOptions}
 let test = join(src, "test.ts"), testConf = {tsOptions, bundleName: "test"}
 
-let rollupFile = join(src, "rollup-plugin-lezer.js")
+let unpluginFile = join(src, "unplugin-lezer.js")
 try { mkdirSync(dist) } catch {}
 
-writeFileSync(join(dist, "rollup-plugin-lezer.js"), readFileSync(rollupFile, "utf8"))
-rollup({
-  input: rollupFile,
-  external: () => true
-}).then(bundle => bundle.generate({
-  format: "cjs",
-  file: join(dist, "rollup-plugin-lezer.cjs"),
-  paths: id => id.endsWith("/index.js") ? "./index.cjs" : id
-})).then(result => {
-  writeFileSync(join(dist, "rollup-plugin-lezer.cjs"), result.output[0].code)
-})
+["cjs", "esm"].map(format =>
+  esbuild.buildSync({
+    entryPoints: [unpluginFile],
+    write: true,
+    bundle: true,
+    platform: "node",
+    format,
+    outExtension: { '.js': format === "esm" ? ".js" : ".cjs" },
+    outdir: dist,
+  })
+)
 
 if (process.argv.includes("--watch")) {
   watch([main], [], mainConf)

--- a/package.json
+++ b/package.json
@@ -18,8 +18,12 @@
       "require": "./dist/test.cjs"
     },
     "./rollup": {
-      "import": "./dist/rollup-plugin-lezer.js",
-      "require": "./dist/rollup-plugin-lezer.cjs"
+      "import": "./dist/unplugin-lezer.js",
+      "require": "./dist/unplugin-lezer.cjs"
+    },
+    "./unplugin": {
+      "import": "./dist/unplugin-lezer.js",
+      "require": "./dist/unplugin-lezer.cjs"
     }
   },
   "module": "dist/index.js",
@@ -27,15 +31,17 @@
   "author": "Marijn Haverbeke <marijn@haverbeke.berlin>",
   "license": "MIT",
   "devDependencies": {
+    "@lezer/lr": "^1.3.14",
     "@marijn/buildtool": "^0.1.6",
     "@types/mocha": "^5.2.6",
     "@types/node": "^20.5.0",
+    "esbuild": "0.19.5",
     "ist": "^1.1.1",
-    "mocha": "^10.2.0"
+    "mocha": "^10.2.0",
+    "unplugin": "^1.5.0"
   },
   "dependencies": {
-    "@lezer/common": "^1.1.0",
-    "@lezer/lr": "^1.3.0"
+    "@lezer/common": "^1.1.0"
   },
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -18,12 +18,24 @@
       "require": "./dist/test.cjs"
     },
     "./rollup": {
-      "import": "./dist/unplugin-lezer.js",
-      "require": "./dist/unplugin-lezer.cjs"
+      "import": {
+        "types": "./dist/unplugin.d.ts",
+        "default": "./dist/unplugin.js"
+      },
+      "require": {
+        "types": "./dist/unplugin.d.cts",
+        "default": "./dist/unplugin.cjs"
+      }
     },
-    "./unplugin": {
-      "import": "./dist/unplugin-lezer.js",
-      "require": "./dist/unplugin-lezer.cjs"
+    "./dist/unplugin": {
+      "import": {
+        "types": "./dist/unplugin.d.ts",
+        "default": "./dist/unplugin.js"
+      },
+      "require": {
+        "types": "./dist/unplugin.d.cts",
+        "default": "./dist/unplugin.cjs"
+      }
     }
   },
   "module": "dist/index.js",
@@ -35,9 +47,9 @@
     "@marijn/buildtool": "^0.1.6",
     "@types/mocha": "^5.2.6",
     "@types/node": "^20.5.0",
-    "esbuild": "0.19.5",
     "ist": "^1.1.1",
     "mocha": "^10.2.0",
+    "tsup": "^7.2.0",
     "unplugin": "^1.5.0"
   },
   "dependencies": {

--- a/src/build.ts
+++ b/src/build.ts
@@ -12,8 +12,7 @@ import {encodeArray} from "./encode"
 import {GenError} from "./error"
 import {verbose, time} from "./log"
 import {NodeProp, NodePropSource} from "@lezer/common"
-import {LRParser, ExternalTokenizer, LocalTokenGroup, Stack, ContextTracker} from "@lezer/lr"
-import {Action, Specialize, StateFlag, Seq, ParseState, File} from "@lezer/lr/dist/constants"
+import {LRParser, ExternalTokenizer, LocalTokenGroup, Stack, ContextTracker, Action, Specialize, StateFlag, Seq, ParseState, File} from "@lezer/lr"
 
 const none: readonly any[] = []
 

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -12,7 +12,7 @@
 //
 // - The digits in a number are ordered from high to low significance.
 
-import {Encode} from "@lezer/lr/dist/constants"
+import {Encode} from "@lezer/lr"
 
 function digitToChar(digit: number) {
   let ch = digit + Encode.Start

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -1,4 +1,4 @@
-import {Term as T} from "@lezer/lr/dist/constants"
+import {Term as T} from "@lezer/lr"
 import {GenError} from "./error"
 
 const enum TermFlag {

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,6 +1,6 @@
 import {Term, union} from "./grammar"
 import {GenError} from "./error"
-import {Seq} from "@lezer/lr/dist/constants"
+import {Seq} from "@lezer/lr"
 
 export const MAX_CHAR = 0xffff
 

--- a/src/unplugin-lezer.js
+++ b/src/unplugin-lezer.js
@@ -1,12 +1,14 @@
+import { createUnplugin } from "unplugin"
+
 import {resolve, dirname} from "path"
 import {promises as fs} from "fs"
 import {buildParserFile} from "./index.js"
 
-export function lezer() {
+export const unpluginLezer = createUnplugin(() => {
   let built = Object.create(null)
 
   return {
-    name: "rollup-plugin-lezer",
+    name: 'unplugin-lezer',
 
     resolveId(source, importer) {
       let m = /^(.*\.grammar)(\.terms)?$/.exec(source)
@@ -32,6 +34,8 @@ export function lezer() {
       if (built[id]) built[id] = null
     }
   }
-}
+})
 
-export const rollup = lezer
+// For backwards compatibility
+export const lezer = unpluginLezer.rollup
+export const rollup = unpluginLezer.rollup

--- a/src/unplugin-lezer.ts
+++ b/src/unplugin-lezer.ts
@@ -27,7 +27,7 @@ export const unpluginLezer = createUnplugin(() => {
         moduleStyle: "es",
         warn: message => this.warn(message)
       })))
-      return build.then(result => m[2] ? result.terms : result.parser)
+      return build.then((result: ReturnType<typeof buildParserFile>) => m?.[2] ? result.terms : result.parser)
     },
 
     watchChange(id) {


### PR DESCRIPTION
I drafted a solution to migrate to unplugin, but ran into some issues in the process. Since we introduce an additional build-time dependency, we need to bundle it to avoid burdening the end user. That means we no longer can simply externalize every dependency and let Node figure it out.

For that reason, I slightly edited the building logic. I decided to replace Rollup with esbuild because it's more out-of-the-box, requires no plugins and less fiddling. That brought me to the problem of the `@lezer/lr` package which contains a `./dist/constants.js` file that actually exports nothing, and isn't mentioned in the `exports` field of `package.json`. To proceed with this, we need to remedy those issues in `@lezer/lr`.

Closes https://github.com/lezer-parser/lezer/issues/48