### PR TITLE
Update rollup-plugin-lezer.js

### DIFF
--- a/src/rollup-plugin-lezer.js
+++ b/src/rollup-plugin-lezer.js
@@ -2,7 +2,7 @@ import {resolve, dirname} from "path"
 import {promises as fs} from "fs"
 import {buildParserFile} from "./index.js"
 
-export function lezer() {
+export function lezer(exportName=undefined) {
   let built = Object.create(null)
 
   return {
@@ -23,6 +23,7 @@ export function lezer() {
       let build = built[base] || (built[base] = fs.readFile(base, "utf8").then(code => buildParserFile(code, {
         fileName: base,
         moduleStyle: "es",
+        exportName: exportName,
         warn: message => this.warn(message)
       })))
       return build.then(result => m[2] ? result.terms : result.parser)

--- a/src/rollup-plugin-lezer.js
+++ b/src/rollup-plugin-lezer.js
@@ -2,9 +2,10 @@ import {resolve, dirname} from "path"
 import {promises as fs} from "fs"
 import {buildParserFile} from "./index.js"
 
-export function lezer(exportName=undefined) {
+export function lezer(config={ exportName:undefined }) {
   let built = Object.create(null)
-
+  let exportName = undefined || config.exportName
+  
   return {
     name: "rollup-plugin-lezer",
 


### PR DESCRIPTION
Added exportName parameter to the lezer rollup function. The lezer generator command line tool allows for an "--export" parameter that allows control of the name exported from the grammar. The rollup tool did not support that parameter.