### PR TITLE
local tokens support precedence

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -219,10 +219,10 @@ class Builder {
       if (value) this.warn(`Unused rule '${value.name}'`, value.start)
     }
 
-    this.tokens.takePrecedences(true)
+    this.tokens.takePrecedences()
     this.tokens.takeConflicts()
     for (let lt of this.localTokens) {
-      lt.takePrecedences(false)
+      lt.takePrecedences()
       lt.takeConflicts()
     }
 
@@ -1515,7 +1515,7 @@ class TokenSet {
     }
   }
 
-  takePrecedences(flag: boolean) {
+  takePrecedences() {
     let rel: {term: Term, after: Term[]}[] = this.precedenceRelations = []
     if (this.ast) for (let group of this.ast.precedences) {
       let prev: Term[] = []
@@ -1529,7 +1529,7 @@ class TokenSet {
           let id = JSON.stringify(item.value), found = this.built.find(b => b.id == id)
           if (found) level.push(found.term)
         }
-        if (!level.length && flag) this.b.warn(`Precedence specified for unknown token ${item}`, item.start)
+        if (!level.length) this.b.warn(`Precedence specified for unknown token ${item}`, item.start)
         for (let term of level) addRel(rel, term, prev)
         prev = prev.concat(level)
       }

--- a/src/node.ts
+++ b/src/node.ts
@@ -75,6 +75,7 @@ export class TokenDeclaration extends Node {
 export class LocalTokenDeclaration extends Node {
   constructor(start: number,
               readonly precedences: readonly TokenPrecDeclaration[],
+              readonly conflicts: readonly TokenConflictDeclaration[],
               readonly rules: readonly RuleDeclaration[],
               readonly fallback: {readonly id: Identifier, readonly props: readonly Prop[]} | null) {
     super(start)

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -441,16 +441,19 @@ function parseLocalTokens(input: Input, start: number) {
   let tokenRules: RuleDeclaration[] = []
   let precedences: TokenPrecDeclaration[] = []
   let fallback: {id: Identifier, props: readonly Prop[]} | null = null
+  let conflicts: TokenConflictDeclaration[] = []
   while (!input.eat("}")) {
     if (input.type == "at" && input.value == "precedence") {
       precedences.push(parseTokenPrecedence(input))
+    } else if (input.type == "at" && input.value == "conflict") {
+      conflicts.push(parseTokenConflict(input))
     } else if (input.eat("at", "else") && !fallback) {
       fallback = {id: parseIdent(input), props: parseProps(input)}
     } else {
       tokenRules.push(parseRule(input))
     }
   }
-  return new LocalTokenDeclaration(start, precedences, tokenRules, fallback)
+  return new LocalTokenDeclaration(start, precedences, conflicts, tokenRules, fallback)
 }
 
 function parseTokenPrecedence(input: Input) {

--- a/test/cases/LocalTokenPrecedence.txt
+++ b/test/cases/LocalTokenPrecedence.txt
@@ -1,0 +1,23 @@
+@top T { expr* }
+
+expr {
+ String { '"' (stringContent | Q | QQ )* stringEnd }
+}
+
+@local tokens {
+  @precedence { QQ, Q }
+
+  stringEnd { '"' }
+  Q { "q" "."? }
+  QQ { "qq" }
+  @else stringContent
+}
+
+# precedence in local tokens
+
+"xqqxq"
+
+==>
+
+T(String(QQ,Q))
+

--- a/test/cases/LocalTokenPrecedence.txt
+++ b/test/cases/LocalTokenPrecedence.txt
@@ -1,23 +1,26 @@
 @top T { expr* }
 
 expr {
- String { '"' (stringContent | Q | QQ )* stringEnd }
+ String { '"' (stringContent | A | AA | Letter)* stringEnd }
 }
 
 @local tokens {
-  @precedence { QQ, Q }
+  @precedence { AA, A }
 
   stringEnd { '"' }
-  Q { "q" "."? }
-  QQ { "qq" }
+  A { "a" "."? }
+  AA { "aa" }
+  Y { "y" }
+  Z { "z" }
+  Letter { Y | Z }
   @else stringContent
 }
 
 # precedence in local tokens
 
-"xqqxq"
+"yaaza"
 
 ==>
 
-T(String(QQ,Q))
+T(String(Letter,AA,Letter,A))
 


### PR DESCRIPTION
This PR makes  `@local tokens` support  `@precedence`.

It's mostly a copy/paste of existing code from `buildTokenGroups`. Do you want to refactor/extract the common logic? I didn't do it because I'm pretty unfamiliar with the code. I can refactor it if you like the overall idea; I'll probably create 2 methods on `TokenSet`: `validate`, and `buildTokenGroup`, which correspond to the 2 copy/paste blocks below.