### PR TITLE
Fix error importing `*.grammar.terms` from vitest

### DIFF
--- a/src/rollup-plugin-lezer.js
+++ b/src/rollup-plugin-lezer.js
@@ -9,6 +9,7 @@ export function lezer(config = {}) {
     name: "rollup-plugin-lezer",
 
     resolveId(source, importer) {
+      if (source.startsWith('\0')) return null
       let m = /^(.*\.grammar)(\.terms)?$/.exec(source)
       if (!m) return null
       let id = resolve(importer ? dirname(importer) : process.cwd(), m[1])


### PR DESCRIPTION
The `vitest` dev server calls `resolveId` a second time with the initially resolved `\0${id}.terms` module id.

When this happens `resolveId` attempts to resolve the module id a second time, but produces an invalid path which looks like `\0${basePath}\0${id}.terms`. This results in an error when the second invalid path gets later passed to `load(id) {}`.

Checking for a leading null byte (`\0`) which is used to identify [virtual modules](https://vitejs.dev/guide/api-plugin#virtual-modules-convention) prevents this second module id resolution attempt.

I created a small reproduction repo which demonstrates the issue: https://github.com/epfremmer/lezer-vitest-repro-1

Hopefully this is helpful 🎉 